### PR TITLE
Bugfix for void* cannot be indexed with number.

### DIFF
--- a/lua/cdata.lua
+++ b/lua/cdata.lua
@@ -90,6 +90,7 @@ function M.tolua(cd, refct)
       -- Don't touch any char*, because we don't know if they are zero
       -- terminated or not
       if cd==nil then res='NULL'
+      elseif refct.element_type.what=='void' then res=tonumber(ffi.cast('intptr_t', ffi.cast('void *', cd))) --cf. http://wiki.luajit.org/ffi-knowledge       	
       elseif is_prim_num(refct.element_type) then res=tonumber(cd[0])
       else res=M.tolua(cd, refct.element_type) end
    else print("can't handle "..refct.what..", ignoring.") end

--- a/tests/test_cdata_tolua.lua
+++ b/tests/test_cdata_tolua.lua
@@ -135,3 +135,10 @@ function test_arr_data()
    local res = ubx.data_tolua(d)
    assert_true(utils.table_cmp(res, init), "test_arr_data double[5] roundtrip failed")
 end
+
+function test_void_pointer_to_prim()
+   local init = 0xdeafbeaf 
+   local vp = ffi.new("void *", ffi.cast('void *', init)) 
+   local val = cdata.tolua(vp)
+   assert_equal(init, val, "L: mismatch after converting from cdata")
+end


### PR DESCRIPTION
This commit fixes the bugfix for void\* cannot be indexed with number. This is e.g. triggered by the web interface while inspepecting custom UBX structs that contain void\* pointers. 

Sebastian
